### PR TITLE
Add ConfigService unit tests

### DIFF
--- a/src/app/services/config.service.spec.ts
+++ b/src/app/services/config.service.spec.ts
@@ -1,0 +1,24 @@
+import { TestBed } from '@angular/core/testing';
+import { ConfigService } from './config.service';
+import { environment } from '../../environments/environment';
+
+describe('ConfigService', () => {
+  let service: ConfigService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(ConfigService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+
+  it('should return the configured pageSize', () => {
+    expect(service.pageSize).toBe(environment.config.pageSize);
+  });
+
+  it('should return the configured stampsPerCard', () => {
+    expect(service.stampsPerCard).toBe(environment.config.stampsPerCard);
+  });
+});


### PR DESCRIPTION
## Summary
- test ConfigService getters for environment values

## Testing
- `npm test --silent -- --browsers=ChromeHeadless --watch=false` *(fails: No binary for ChromeHeadless)*

------
https://chatgpt.com/codex/tasks/task_e_684607f68900832687a5370904c9e1c4